### PR TITLE
Fix sidepanel and page cleanup

### DIFF
--- a/polls/templates/polls/admin-batch-submit.html
+++ b/polls/templates/polls/admin-batch-submit.html
@@ -1,7 +1,11 @@
 {% extends 'base.html' %}
 {% block body-block %}
-<h1> Admin Batch submit Form </h1>
-
+<div class="mb-5 text-center">
+    <h1 class="mt-5 text-center mb-5">Admin Batch Submit Form </h1>
+    <p>This page allows admin users to create batch of tasks for any of their existing experiment in the database,
+        This is done by pasting a well formated JSON in the text box below.
+    </p>
+</div>
 <form hx-post="{% url 'admin-batch-submit' %}" hx-swap="innerHTML" 
     hx-target="#body" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
     <div class="mb-3">

--- a/polls/templates/polls/admin-management.html
+++ b/polls/templates/polls/admin-management.html
@@ -2,8 +2,13 @@
 {% load custom_tags %}
 
 {% block body-block %}
-
-    <h1 class="mt-5 text-center mb-5">Admin management view</h1>
+<div class="mb-5 text-center">
+    <h1 class="mt-5 text-center mb-5">Admin User Management View</h1>
+    <p>This page displays all users with their respective stats, on this page, 
+        admin can lock a user out of the page and he can as well delete all their 
+        available tasks by clicking on the "lock/unlock" or "delete"</p>
+</div>
+    
 <table class="table table-striped">
     <thead>
         <tr>

--- a/polls/templates/polls/admin-management.html
+++ b/polls/templates/polls/admin-management.html
@@ -6,7 +6,7 @@
     <h1 class="mt-5 text-center mb-5">Admin User Management View</h1>
     <p>This page displays all users with their respective stats, on this page, 
         admin can lock a user out of the page and he can as well delete all their 
-        available tasks by clicking on the "lock/unlock" or "delete"</p>
+        available tasks by clicking on their "lock/unlock" or "delete"</p>
 </div>
     
 <table class="table table-striped">

--- a/polls/templates/polls/admin_dashboard.html
+++ b/polls/templates/polls/admin_dashboard.html
@@ -8,9 +8,10 @@
         <p>This page displays all available experiment with index and shows their
             respective batches under each experiment in a table</p>
     </div>
-    <ol>
+    <ol class="text-primary">
         {% for experiment in experiments %}
-        <li class="text-align-left text-bold h4" hx-get="{% url 'admin_experiment' experiment_id=experiment.id%}" hx-target="#body">
+        <li class="text-align-left text-bold h4" hx-get="{% url 'admin_experiment' experiment_id=experiment.id%}" 
+        hx-target="#body" class="text-primary">
             {{experiment.name}}
         </li>
     </ol>

--- a/polls/templates/polls/admin_dashboard.html
+++ b/polls/templates/polls/admin_dashboard.html
@@ -3,12 +3,17 @@
 {% block body-block %}
 
 <div class="mt-5">
-    <h1>Admin View Dashboard</h1>
-    <ul>
+    <div class="mb-5 text-center">
+        <h1>Admin View Dashboard</h1>
+        <p>This page displays all available experiment with index and shows their
+            respective batches under each experiment in a table</p>
+    </div>
+    <ol>
         {% for experiment in experiments %}
-            <li class="text-align-left text-bold" hx-get="{% url 'admin_experiment' experiment_id=experiment.id%}" hx-target="#body">
-                {{experiment.name}}
-            </li>
+        <li class="text-align-left text-bold h4" hx-get="{% url 'admin_experiment' experiment_id=experiment.id%}" hx-target="#body">
+            {{experiment.name}}
+        </li>
+    </ol>
             <table class="table table-striped">
                 <thead>
                     <tr>
@@ -36,7 +41,6 @@
                 </tbody>
             </table>
         {% endfor %}
-        <ul>
     <h5>Go to admin panel: <a href="/admin">admin</a></h5>
 </div>
 {% endblock %}

--- a/polls/templates/polls/admin_experiment.html
+++ b/polls/templates/polls/admin_experiment.html
@@ -3,7 +3,7 @@
 {% block body-block %}
 
 <div class="mt-5 text-center">
-    <h1>Admin View Experiment</h1>
+    <h1>Admin Experiment Details </h1>
 
     {% if error_message %}
 
@@ -11,8 +11,8 @@
 
     {% else %}
 
-    <p><strong>Name: </strong> {{experiment.name}}</p>
-    <p><strong>Type: </strong> {{experiment.experiment_type}}</p>
+    <p><strong>Experiment Name: </strong> {{experiment.name}}</p>
+    <p><strong>Experiment Type: </strong> {{experiment.experiment_type}}</p>
 
 
     {% for item in data_list %}

--- a/polls/templates/polls/create-experiment-form.html
+++ b/polls/templates/polls/create-experiment-form.html
@@ -1,6 +1,10 @@
 {% extends 'base.html' %}
 {% block body-block %}
-<h2>Create a new Experiment</h2>
+<div class="mb-5 text-center">
+  <h1 class="mt-5 text-center mb-5">Create a New Experiment</h1>
+  <p>Create a new experiment by selecting an experiment type and giving your experiment a name, 
+    you can then create some batch tasks for the experiment later.</p>
+</div>
 <form hx-post="{% url 'create-experiment' %}" hx-boost="true"
 hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
     <div class="mb-3">

--- a/themeapp/templates/widgets/sidebar.html
+++ b/themeapp/templates/widgets/sidebar.html
@@ -6,12 +6,26 @@
 
     </div>
     <div class="list-group list-group-flush">
-        <a class="list-group-item list-group-item-action list-group-item-light p-3" href="#!">Dashboard</a>
-        <a class="list-group-item list-group-item-action list-group-item-light p-3" href="{% url 'admin-management' %}">management</a>
-        <a class="list-group-item list-group-item-action list-group-item-light p-3" href="{% url 'admin-batch-submit' %}">batch</a>
-        <a class="list-group-item list-group-item-action list-group-item-light p-3" href="#!">Events</a>
-        <a class="list-group-item list-group-item-action list-group-item-light p-3" href="#!">Profile</a>
-        <a class="list-group-item list-group-item-action list-group-item-light p-3" href="#!">Status</a>
-        <a class="list-group-item list-group-item-action list-group-item-light p-3" href="{% url 'admin_dashboard' %}">Admin Dashboard</a>
+        <a class="list-group-item list-group-item-action 
+        list-group-item-light p-3" href="{% url 'admin_dashboard' %}">
+        Dashboard</a>
+        <a class="list-group-item list-group-item-action 
+        list-group-item-light p-3" href="{% url 'admin-management' %}">
+        User Management</a>
+        <a class="list-group-item list-group-item-action 
+        list-group-item-light p-3" href="{% url 'admin-batch-submit' %}">
+        Batch Submit</a>
+        <a class="list-group-item list-group-item-action 
+        list-group-item-light p-3" href="{% url 'create-experiment' %}">
+        Create Experiment</a>
+        <a class="list-group-item list-group-item-action 
+        list-group-item-light p-3" href="#!">
+        Manage Experiments</a>
+        <a class="list-group-item list-group-item-action 
+        list-group-item-light p-3" href="#!">
+        Status</a>
+        <a class="list-group-item list-group-item-action 
+        list-group-item-light p-3" href="{% url 'admin_dashboard' %}">
+        Admin Dashboard</a>
     </div>
 </div>

--- a/themeapp/templates/widgets/sidebar.html
+++ b/themeapp/templates/widgets/sidebar.html
@@ -19,15 +19,11 @@
         <a class="list-group-item list-group-item-action 
         list-group-item-light p-3" href="{% url 'create-experiment' %}">
         Create Experiment</a>
+        
         <a class="list-group-item list-group-item-action 
         list-group-item-light p-3" href="#!">
-        Manage Experiments</a>
-        <a class="list-group-item list-group-item-action 
-        list-group-item-light p-3" href="#!">
-        Status</a>
-        <a class="list-group-item list-group-item-action 
-        list-group-item-light p-3" href="{% url 'admin_dashboard' %}">
-        Admin Dashboard</a>
+        Empty</a>
+        
     </div>
 </div>
 {% endif %}

--- a/themeapp/templates/widgets/sidebar.html
+++ b/themeapp/templates/widgets/sidebar.html
@@ -5,6 +5,7 @@
         <p>Audio Discrimination</p>
 
     </div>
+    {% if request.user.is_superuser %}
     <div class="list-group list-group-flush">
         <a class="list-group-item list-group-item-action 
         list-group-item-light p-3" href="{% url 'admin_dashboard' %}">
@@ -29,3 +30,4 @@
         Admin Dashboard</a>
     </div>
 </div>
+{% endif %}


### PR DESCRIPTION
Closes #146 

This involves available admin page cleanup and sidebar restructuring, rearrangement and putting a restriction so it's visible to only admin users.

Screenshots:
![Screenshot 2023-03-10 164659](https://user-images.githubusercontent.com/68183305/224362612-ff648e5e-fab3-4d9d-af4c-1ae2764c9b3c.png)
![Screenshot 2023-03-10 152102](https://user-images.githubusercontent.com/68183305/224362695-cfc268fd-29c6-4013-aacb-9575304d4122.png)

![Screenshot 2023-03-10 163232](https://user-images.githubusercontent.com/68183305/224362803-8dd25cc0-4a43-4d34-8154-55ed132240bc.png)

![Screenshot 2023-03-10 164255](https://user-images.githubusercontent.com/68183305/224362883-d1aadf46-bb24-4c25-a4f4-0f31422c9b28.png)
