### PR TITLE
Experiment type MGT page

### DIFF
--- a/polls/templates/polls/experiment-type-annotation.html
+++ b/polls/templates/polls/experiment-type-annotation.html
@@ -1,11 +1,9 @@
-{% extends 'base.html' %}
-{% block body-block %}
 <div class="mt-5 mb-5 text-center">
-    <h2>Create Experiment-type Annotation</h2>
+    <h3>Create Experiment-type Annotation</h3>
     <p></p>
 </div>
 <form hx-post="{% url 'experiment-type-annotation' %}" hx-swap="innerHTML"
-    hx-target="#body" hx-boost="true" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+    hx-target="#form-response" hx-boost="true" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
     
     <div class="mb-3">
         <label for="annotation" class="form-label">Input annotation pattern:</label>
@@ -23,6 +21,6 @@
         </select>
       </div>
     <button type="submit" class="btn btn-primary">Submit Experiment-type Annotation</button>
+    
 </form>
-
-{% endblock body-block %}
+<div id="form-response"><div>

--- a/polls/templates/polls/experiment-type-creation-management.html
+++ b/polls/templates/polls/experiment-type-creation-management.html
@@ -1,19 +1,27 @@
 {% extends 'base.html' %}
-{% endblock css-block%}
 {% block body-block %}
 <div class="mt-5 mb-5 text-center">
     <h2 class="text-bold"> ExperimentType Creation Management</h2>
     <p>Each experiment-type comes with different task presentation and task annotation orientation,
         after creating an experiment type, say A/B, you'll need to create all ExperimentType-task-presentation for it,
-        which for example can look like, AA, AB, BA etc. Also you'll need to create an ExperimentType-task-annotation for it,
+        which for example can look like, AA, AB, BA etc. Also you'll need to create an ExperimentType-annotation for it,
         which can for example look like XX, XY, YX etc. If you don't understand this, headover to the Admin Quickstart page.
     </p>
 </div>
 <div class="container-fluid">
     <div class="row">
-      <div class="col">Column 1</div>
-      <div class="col">Column 2</div>
-      <div class="col">Column 3</div>
+      <div class="col">
+        <p hx-get="{% url "experiment-type" %}" hx-target="#page-result" hx-swap="innerHTML" 
+            class="text-bold">Experiment Type</p>
+      </div>
+      <div class="col">
+        <p hx-get="{% url "experiment-type" %}" hx-target="#page-result" hx-swap="innerHTML" 
+            class="text-bold">ExperimentType Task Presentation</p>
+      </div>
+      <div class="col">
+        <p hx-get="{% url "experiment-type" %}" hx-target="#page-result" hx-swap="innerHTML" 
+            class="text-bold">ExperimentType Annotation</p>
+      </div>
     </div>
   </div>
 <div id="page-result"></div>

--- a/polls/templates/polls/experiment-type-creation-management.html
+++ b/polls/templates/polls/experiment-type-creation-management.html
@@ -15,11 +15,11 @@
             class="text-bold">Experiment Type</p>
       </div>
       <div class="col">
-        <p hx-get="{% url "experiment-type" %}" hx-target="#page-result" hx-swap="innerHTML" 
+        <p hx-get="{% url "experiment_type_task_presentation" %}" hx-target="#page-result" hx-swap="innerHTML" 
             class="text-bold">ExperimentType Task Presentation</p>
       </div>
       <div class="col">
-        <p hx-get="{% url "experiment-type" %}" hx-target="#page-result" hx-swap="innerHTML" 
+        <p hx-get="{% url "experiment-type-annotation" %}" hx-target="#page-result" hx-swap="innerHTML" 
             class="text-bold">ExperimentType Annotation</p>
       </div>
     </div>

--- a/polls/templates/polls/experiment-type-creation-management.html
+++ b/polls/templates/polls/experiment-type-creation-management.html
@@ -1,5 +1,6 @@
-{% extends "base.html" %}
-{% block "body-block" %}
+{% extends 'base.html' %}
+{% endblock css-block%}
+{% block body-block %}
 <div class="mt-5 mb-5 text-center">
     <h2 class="text-bold"> ExperimentType Creation Management</h2>
     <p>Each experiment-type comes with different task presentation and task annotation orientation,
@@ -8,6 +9,12 @@
         which can for example look like XX, XY, YX etc. If you don't understand this, headover to the Admin Quickstart page.
     </p>
 </div>
-
+<div class="container-fluid">
+    <div class="row">
+      <div class="col">Column 1</div>
+      <div class="col">Column 2</div>
+      <div class="col">Column 3</div>
+    </div>
+  </div>
 <div id="page-result"></div>
-{% endblock "body-block" %}
+{% endblock body-block %}

--- a/polls/templates/polls/experiment-type-creation-management.html
+++ b/polls/templates/polls/experiment-type-creation-management.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block "body-block" %}
+<div class="mt-5 mb-5 text-center">
+    <h2 class="text-bold"> ExperimentType Creation Management</h2>
+    <p>Each experiment-type comes with different task presentation and task annotation orientation,
+        after creating an experiment type, say A/B, you'll need to create all ExperimentType-task-presentation for it,
+        which for example can look like, AA, AB, BA etc. Also you'll need to create an ExperimentType-task-annotation for it,
+        which can for example look like XX, XY, YX etc. If you don't understand this, headover to the Admin Quickstart page.
+    </p>
+</div>
+
+<div id="page-result"></div>
+{% endblock "body-block" %}

--- a/polls/templates/polls/experiment-type-creation-management.html
+++ b/polls/templates/polls/experiment-type-creation-management.html
@@ -24,5 +24,5 @@
       </div>
     </div>
   </div>
-<div id="page-result"></div>
+<div id="page-result" class="m-4 item-center"></div>
 {% endblock body-block %}

--- a/polls/templates/polls/experiment-type-form.html
+++ b/polls/templates/polls/experiment-type-form.html
@@ -1,14 +1,18 @@
-{% extends 'base.html' %}
-{% block body-block %}
-<h1 class="page-header">Create new experiment type below</h1>
+<div class="mt-5 mb-5 text-center">
+  <h3>Create new Experiment Type below</h3>
+  <p>Experiment types represent and explains what manner of test do you want to carry out,
+    and depends on ExperimentType-task-presentation and 
+    ExperimentType-annotation to get all credible experiment formatting data, 
+    after creating experiment-type, 
+    you will need to create those in the next tab above.</p>
+</div>
 <form hx-post="{% url 'experiment-type' %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
     <div class="mb-3">
-      <label for="text-field" class="form-label">Experiment Type</label>
-      <input type="text" class="form-control" id="text-field" name="experiment-type" placeholder="eg: AAB/ABB/BAB">
+      <label for="text-field" class="form-label">Experiment Type Code</label>
+      <input type="text" class="form-control" id="text-field" name="experiment-type" placeholder="eg: 2AFC, A/B ...">
     </div>
     <button type="submit" class="btn btn-primary" hx-target="#form-result">Create experiment type</button>
   </form>
-  <div id="form-result"></div>
   
-  
-{% endblock body-block %}
+</form>
+<div id="form-result"></div>

--- a/polls/templates/polls/experiment_type_task_presentation.html
+++ b/polls/templates/polls/experiment_type_task_presentation.html
@@ -1,10 +1,8 @@
-{% extends 'base.html' %}
-{% block body-block %}
 <div class="mt-5 mb-5 text-center">
-    <h2>Create Experiment-type Task Presentation</h2>
+    <h3>Create Experiment-type Task Presentation</h3>
     <p></p>
 </div>
-<form hx-post="{% url 'experiment_type_task_presentation' %}" hx-swap="innerHTML" hx-target="#body" hx-boost="true"
+<form hx-post="{% url 'experiment_type_task_presentation' %}" hx-swap="innerHTML" hx-target="#responses" hx-boost="true"
     hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
 
     <div class="mb-3">
@@ -26,6 +24,6 @@
         </select>
     </div>
     <button type="submit" class="btn btn-primary">Submit Experiment-type Presentation</button>
-</form>
 
-{% endblock body-block %}
+</form>
+<div id="responses"></div>

--- a/polls/urls.py
+++ b/polls/urls.py
@@ -68,6 +68,11 @@ urlpatterns = [
         views.CreateExperimentTypeTaskPresentationView.as_view(),
         name="experiment_type_task_presentation",
     ),
+    path(
+        "admin/experiment-type/management/",
+        views.ManageExperimentTypeCreationView.as_view(),
+        name="experiment-type-creation",
+    ),
     # APIs
     path("api/v1/admin-api/", views.AdminAPIView.as_view(), name="admin-api-url"),
     path(

--- a/polls/views.py
+++ b/polls/views.py
@@ -468,6 +468,11 @@ class CreateExperimentTypeTaskPresentationView(
         return self.request.user.is_superuser
 
 
+class ManageExperimentTypeCreationView(LoginRequiredMixin, UserPassesTestMixin, View):
+    def test_func(self):
+        return self.request.user.is_superuser
+
+
 # **************** API Views ******************* #
 class AnnotationListAPI(mixins.ListModelMixin, generics.GenericAPIView):
     queryset = Annotation.objects.all()

--- a/polls/views.py
+++ b/polls/views.py
@@ -304,6 +304,9 @@ class AdminCreateExperimentTypeView(LoginRequiredMixin, UserPassesTestMixin, Vie
             create_type.save()
             return HttpResponse("successfully created")
 
+    def test_func(self):
+        return self.request.user.is_superuser
+
 
 class AdminCreateExperimentView(LoginRequiredMixin, UserPassesTestMixin, View):
     def get(self, request):
@@ -437,7 +440,7 @@ class CreateExperimentTypeAnnotationView(LoginRequiredMixin, UserPassesTestMixin
             return HttpResponse("Select experiment type from dropdown")
 
     def test_func(self):
-        return self.request.user.is_superuserS
+        return self.request.user.is_superuser
 
 
 class CreateExperimentTypeTaskPresentationView(

--- a/polls/views.py
+++ b/polls/views.py
@@ -302,7 +302,7 @@ class AdminCreateExperimentTypeView(LoginRequiredMixin, UserPassesTestMixin, Vie
                 type=str(new_experiment_type).upper()
             )
             create_type.save()
-            return HttpResponse("successfully created")
+            return HttpResponse("successfully created new experiment type")
 
     def test_func(self):
         return self.request.user.is_superuser
@@ -434,7 +434,7 @@ class CreateExperimentTypeAnnotationView(LoginRequiredMixin, UserPassesTestMixin
             )
             exp_type_annotation.save()
 
-            return HttpResponseRedirect(reverse("admin-dashboard"))
+            return HttpResponse("Successfully created new experiment type annotation")
 
         else:
             return HttpResponse("Select experiment type from dropdown")
@@ -462,7 +462,7 @@ class CreateExperimentTypeTaskPresentationView(
             )
             exp_type_annotation.save()
 
-            return HttpResponseRedirect(reverse("admin_dashboard"))
+            return HttpResponse("Successfully added new type task presentation")
 
         except ExperimentType.DoesNotExist:
             return HttpResponse("Select experiment type from dropdown")

--- a/polls/views.py
+++ b/polls/views.py
@@ -469,6 +469,9 @@ class CreateExperimentTypeTaskPresentationView(
 
 
 class ManageExperimentTypeCreationView(LoginRequiredMixin, UserPassesTestMixin, View):
+    def get(self, request):
+        return render(request, "polls/experiment-type-creation-management.html")
+
     def test_func(self):
         return self.request.user.is_superuser
 

--- a/themeapp/templates/widgets/sidebar.html
+++ b/themeapp/templates/widgets/sidebar.html
@@ -21,8 +21,8 @@
         Create Experiment</a>
         
         <a class="list-group-item list-group-item-action 
-        list-group-item-light p-3" href="#!">
-        Empty</a>
+        list-group-item-light p-3" href="{% url "experiment-type-creation" %}">
+        Experiment Type Mgt</a>
     </div>
     {% endif %}
     {% if not request.user.is_authenticated %}


### PR DESCRIPTION
Closes #163 

This PR implement a page where experiment type and it's dependencies can be created from the same page but with different tab.
Changing tabs is powered by HTMX and it requires just a click to switch amongst the form for creating `Experiment Type`, `Experiment Type Task Presentation` and `Experiment Type Annotation`.
Also, there is removal of all `{% extends 'base.html %}` and `{% block body-block %} ` from all previously created pages to make them fit for the new page.

This PR also clean up all response from views to respond with just `HttpResponse` instead of  `HttpResponseRedirect` for all the three views.

Screenshot on the landing on the Experiment type MGT page:
![Screenshot 2023-03-15 175317](https://user-images.githubusercontent.com/68183305/225383741-dcc4f734-5f2a-4a8e-9ecb-5b1ad6466dbc.png)

Screenshot after clicking on `Expeperiment type` column:
![Screenshot 2023-03-15 175433](https://user-images.githubusercontent.com/68183305/225384150-310a9f3b-416c-42d4-bd62-53cdd64dddf7.png)

Screenshot after clicking on `ExperimentType task presentation`:
![Screenshot 2023-03-15 175531](https://user-images.githubusercontent.com/68183305/225384492-48926e98-9961-4715-b7a7-2d7ef0e1da84.png)

Screenshot after clicking on `ExperimentType Annotation`:
![Screenshot 2023-03-15 175604](https://user-images.githubusercontent.com/68183305/225384670-eb033385-bcb3-4d53-ab07-d4a1acc483c6.png)
